### PR TITLE
Store previous ticker data so multiple CurrentMarket instances can ex…

### DIFF
--- a/test/coinray-cache.test.ts
+++ b/test/coinray-cache.test.ts
@@ -5,9 +5,9 @@ jest.setTimeout(30000);
 import Coinray from "../lib";
 import CoinrayCache from "../lib/coinray-cache";
 
-const coinray = new Coinray(coinrayToken)
 const coinrayToken = ""
-const coinrayCache = new CoinrayCache(coinray)
+const coinray = new Coinray(coinrayToken)
+const coinrayCache = new CoinrayCache(coinrayToken,{apiEndpoint: "https://api.coinray.eu"})
 
 beforeAll(async () => {
   await coinrayCache.initialize()


### PR DESCRIPTION
Previously, if there were multiple instances of `CurrentMarket`: for every trades- or orderbook-update from `Coinray`, only the `CurrentMarket` object that would call `market.updateTicker` first would get to dispatch a `marketUpdated` event. The other `CurrentMarket` objects would not fire their event. 
This has been fixed by comparing the ticker-data to previous data that's stored per `CurrentMarket` instance.